### PR TITLE
feat(logical-types): add support for using logical types in a schema

### DIFF
--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -46,7 +46,7 @@ const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null, s
   }
   const parsedSchema = avsc.parse(schema, parseOptions);
   // We get the schema string to upload to the schema registry from the now parsed schema with resolved dependencies
-  const schemaString = JSON.stringify(parsedSchema.getSchema());
+  const schemaString = JSON.stringify(parsedSchema.toJSON());
   let id = registry.cache.getBySchema(parsedSchema);
   if (id) {
     return Promise.resolve(id)


### PR DESCRIPTION
The old way of using getSchema for the avsc-parsed schema would strip away any extra attributes on a property. For instance precision and scale for the 'decimal' logical type. Using 'toJSON' instead keeps attributes, so the correct version of the schema gets uploaded to the schema registry